### PR TITLE
Start checking for valid fields in LAZ & copc-info VLRs

### DIFF
--- a/src/suites/vlrs.test.ts
+++ b/src/suites/vlrs.test.ts
@@ -47,7 +47,7 @@ test('manualVlrSuite failures', async () => {
   })
   checkAll(checks, false)
 
-  let expectedOutput = [
+  const expectedOutput = [
     {
       id: 'wkt',
       status: 'fail',

--- a/src/suites/vlrs.test.ts
+++ b/src/suites/vlrs.test.ts
@@ -47,32 +47,46 @@ test('manualVlrSuite failures', async () => {
   })
   checkAll(checks, false)
 
+  let expectedOutput = [
+    {
+      id: 'wkt',
+      status: 'fail',
+      info: '',
+      description:
+        'WKT VLR (string) exists and successfully initializes proj4js',
+    },
+    {
+      id:'laz',
+      status: 'fail',
+      info: '',
+      description:
+        'LAZ VLR exists and contains valid data fields',
+    },
+    {
+      id:'copc-info',
+      status: 'fail',
+      info: '',
+      description:
+        'COPC info VLR exists and contains valid data fields',
+    }
+  ]
+
   const emptyVlrChecks = await invokeAllChecks({
     source: { get, vlrs: [] },
     suite: manualVlrSuite,
   })
-  expect(emptyVlrChecks).toEqual([
-    {
-      id: 'wkt',
-      status: 'fail',
-      info: 'Failed to find WKT SRS VLR',
-      description:
-        'WKT VLR (string) exists and successfully initializes proj4js',
-    },
-  ])
+  expectedOutput[0].info = 'Failed to find WKT SRS VLR'
+  expectedOutput[1].info = 'Failed to find LAZ VLR'
+  expectedOutput[2].info = 'Failed to find copc-info VLR'
+  expect(emptyVlrChecks).toEqual(expectedOutput)
 
   const doubleVlrChecks = await invokeAllChecks({
     source: { get, vlrs: vlrs.concat(vlrs) },
     suite: manualVlrSuite,
   })
-  expect(doubleVlrChecks).toEqual([
-    {
-      id: 'wkt',
-      status: 'fail',
-      info: 'Found multiple WKT SRS VLRs',
-      description:
-        'WKT VLR (string) exists and successfully initializes proj4js',
-    },
-  ])
+  expectedOutput[0].info = 'Found multiple WKT SRS VLRs'
+  expectedOutput[1].info = 'Found multiple LAZ VLRs'
+  expectedOutput[2].info = 'Found multiple copc-info VLRs'
+  expect(doubleVlrChecks).toEqual(expectedOutput)
   // checkAll(doubleVlrChecks, false)
 })

--- a/src/suites/vlrs.ts
+++ b/src/suites/vlrs.ts
@@ -119,9 +119,6 @@ export const manualVlrSuite: Check.Suite<{ get: Getter; vlrs: Las.Vlr[] }> = {
   }
 }
 
-// The VLR values could be extracted and encapsulated in lazVlr/copcInfoVlr objects
-// akin to lazperf, especially if the values are used to check things elsewhere.
-
 function checkLazVlr(data: DataView) {
   const UINT32_MAX = 0xFFFFFFFF
   // only checking the chunk size & coder for now.


### PR DESCRIPTION
Sync with hobuinc/copcverify#3. Adds checks for correct values in VLRs; currently checks that `coder` == 0 & `chunk size`  == UINT32_MAX in the LAZ VLR, and all reserved fields are 0 in the COPC info VLR.

I can add other checks for VLR values, if desired